### PR TITLE
Http client fix

### DIFF
--- a/src/main/scala/com/github/cupenya/gateway/client/GatewayTargetClient.scala
+++ b/src/main/scala/com/github/cupenya/gateway/client/GatewayTargetClient.scala
@@ -16,8 +16,6 @@ class GatewayTargetClient(val host: String, val port: Int, secured: Boolean)(
     implicit
     val system: ActorSystem, ec: ExecutionContext, materializer: Materializer
 ) extends StrictLogging {
-  private val connector = Http(system).outgoingConnection(host, port)
-
   private val authClient = new AuthServiceClient(
     Config.integration.authentication.host,
     Config.integration.authentication.port
@@ -62,9 +60,8 @@ class GatewayTargetClient(val host: String, val port: Int, secured: Boolean)(
 
     logger.debug(s"Proxying request: $proxiedRequest")
 
-    Source.single(proxiedRequest)
-      .via(connector)
-      .runWith(Sink.head)
+    Http(system)
+      .singleRequest(proxiedRequest)
       .flatMap(context.complete(_))
   }
 

--- a/src/main/scala/com/github/cupenya/gateway/client/GatewayTargetClient.scala
+++ b/src/main/scala/com/github/cupenya/gateway/client/GatewayTargetClient.scala
@@ -56,9 +56,12 @@ class GatewayTargetClient(val host: String, val port: Int, secured: Boolean)(
   private def proxyRequest(context: RequestContext, request: HttpRequest, headers: List[HttpHeader]) = {
     val proxiedRequest = context.request.copy(
       uri = createProxiedUri(context, request.uri),
-      headers = headers
+      headers = headers,
+      protocol = HttpProtocols.`HTTP/1.1`
     )
+
     logger.debug(s"Proxying request: $proxiedRequest")
+
     Source.single(proxiedRequest)
       .via(connector)
       .runWith(Sink.head)


### PR DESCRIPTION
This fixes an issue encountered with Python/Flask based services where only traffic from the gateway was rejected due some some strange connection/request behavior. I'm still not clear what the actual problem with the requests was but I've tested this fix extensively and it does get rid of the issues.

This fix is based on the recommendations described in the Akka Http docs, which state that the preferred HTTP client layer is the `singleRequest` API, with the connection pool based `cachedHostConnectionPool` method available for use with Akka streams. The gateway was using the underlying, lowest level pure connection-based `outgoingConnection` layer, which is strongly not recommended since it creates single throwaway connections instead of using a connection pool per host.

I also noticed that requests were coming in through HTTP 1.1, which was surprising. I changed the proxied request to always be made using HTTP 1.1 just to be sure. I could revert that but it seems like a good idea.