### PR TITLE
Added Datadog metrics and upgraded to latest Scala and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ project/plugins/project/
 # ENSIME specific
 .ensime_cache/
 .ensime
+/.bsp

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.4.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,9 @@
 resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("com.typesafe.sbt" %% "sbt-native-packager" % "1.7.3")
+addSbtPlugin("com.typesafe.sbt" %% "sbt-native-packager" % "1.7.6")
+addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.5")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -8,7 +8,10 @@
     </encoder>
   </appender>
 
-  <root level="debug">
+  <logger name="com.github.cupenya" level="DEBUG" />
+  <logger name="kamon"              level="DEBUG" />
+
+  <root level="INFO">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -69,7 +69,7 @@ service-discovery {
     namespaces = ["default"]
   }
 
-  polling.interval = 2 seconds
+  polling.interval = 5 seconds
 }
 
 kamon {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,6 +1,25 @@
 akka {
   loglevel = INFO
   loggers = ["akka.event.slf4j.Slf4jLogger"]
+
+  http {
+    host-connection-pool {
+      max-open-requests = 1024
+      max-open-requests = ${?MAX_OPEN_REQUESTS_PER_TARGET}
+
+      max-connections = 128
+      max-connections = ${?MAX_CONNECTIONS_PER_TARGET}
+    }
+
+    client.parsing.max-content-length = 64m
+    client.parsing.max-content-length = ${?MAX_CONTENT_LENGTH}
+
+    server.parsing.max-content-length = 64m
+    server.parsing.max-content-length = ${?MAX_CONTENT_LENGTH}
+
+    server.request-timeout = 120s
+    server.request-timeout = ${?REQUEST_TIMEOUT}
+  }
 }
 
 gateway {
@@ -51,4 +70,85 @@ service-discovery {
   }
 
   polling.interval = 2 seconds
+}
+
+kamon {
+  metric.tick-interval = 15 seconds
+
+  environment {
+    service = "api-gateway"
+
+    tags {
+      env-k8s-deployment-name = ${?K8S_ENV_DEPLOYMENT_NAME}
+      env-k8s-pod-name = ${?K8S_ENV_POD_NAME}
+      env-k8s-namespace = ${?K8S_ENV_NAMESPACE}
+      env-k8s-image-name = ${?K8S_ENV_IMAGE_NAME}
+    }
+  }
+
+  modules {
+    datadog-agent {
+      enabled = false
+    }
+
+    datadog-trace-agent {
+      enabled = false
+    }
+
+    datadog-api {
+      enabled = true
+    }
+  }
+
+  instrumentation.akka.http {
+    server {
+      metrics.enabled = yes
+
+      propagation {
+        enabled = yes
+        channel = default
+      }
+      tracing {
+        enabled = yes
+        span-metrics = on
+      }
+    }
+
+    client {
+      propagation {
+        enabled = yes
+        channel = default
+      }
+      tracing {
+        enabled = yes
+        span-metrics = on
+      }
+    }
+  }
+
+  datadog {
+    api {
+      # API endpoint to which metrics time series data will be posted.
+      api-url = "https://app.datadoghq.com/api/v1/series"
+
+      # Datadog API key to use to send metrics to Datadog directly
+      # over HTTPS. The API key will be combined with the API URL
+      # to get the complete endpoint used for posting time series
+      # to Datadog.
+      api-key = ""
+      api-key = ${?DATADOG_API_KEY}
+
+      # HTTP client timeout settings:
+      #   - connect-timeout: how long to wait for an HTTP connection
+      #     to establish before failing the request.
+      #   - read-timeout: how long to wait for a read IO operation
+      #     to complete before failing the request.
+      #   - write-timeout: how long to wait for a write IO operation
+      #     to complete before failing the request.
+      #
+      connect-timeout = 5 seconds
+      read-timeout = 5 seconds
+      write-timeout = 5 seconds
+    }
+  }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -80,7 +80,6 @@ kamon {
 
     tags {
       env-k8s-deployment-name = ${?K8S_ENV_DEPLOYMENT_NAME}
-      env-k8s-pod-name = ${?K8S_ENV_POD_NAME}
       env-k8s-namespace = ${?K8S_ENV_NAMESPACE}
       env-k8s-image-name = ${?K8S_ENV_IMAGE_NAME}
     }
@@ -96,7 +95,8 @@ kamon {
     }
 
     datadog-api {
-      enabled = true
+      enabled = false
+      enabled = ${?DATADOG_ENABLED}
     }
   }
 
@@ -105,28 +105,33 @@ kamon {
       metrics.enabled = yes
 
       propagation {
-        enabled = yes
+        enabled = no
         channel = default
       }
       tracing {
-        enabled = yes
-        span-metrics = on
+        enabled = no
+        span-metrics = off
       }
     }
 
     client {
       propagation {
-        enabled = yes
+        enabled = no
         channel = default
       }
       tracing {
-        enabled = yes
-        span-metrics = on
+        enabled = no
+        span-metrics = off
       }
     }
   }
 
   datadog {
+    environment-tags {
+      include-instance = no
+      include-host = no
+    }
+
     api {
       # API endpoint to which metrics time series data will be posted.
       api-url = "https://app.datadoghq.com/api/v1/series"

--- a/src/main/scala/com/github/cupenya/gateway/Boot.scala
+++ b/src/main/scala/com/github/cupenya/gateway/Boot.scala
@@ -80,13 +80,20 @@ object Boot
         .contains(upd.namespace)
     }
     val currentResources = GatewayConfigurationManager.currentConfig().targets.keys.toList
-    val toDelete         = currentResources.filterNot(serviceUpdates.map(_.resource).contains)
-    log.debug(s"Deleting $toDelete")
+
+    val toDelete = currentResources.filterNot(serviceUpdates.map(_.resource).contains)
+    if (toDelete.nonEmpty) {
+      log.debug(s"Removed services: $toDelete")
+    }
+
     toDelete.foreach(GatewayConfigurationManager.deleteGatewayTarget)
 
     // TODO: handle config updates
     val newResources = serviceUpdates.filterNot(su => currentResources.contains(su.resource))
-    log.debug(s"New services $newResources")
+    if (newResources.nonEmpty) {
+      log.debug(s"New services: $newResources")
+    }
+
     newResources.foreach(serviceUpdate => {
       val gatewayTarget =
         GatewayTarget(serviceUpdate.resource, serviceUpdate.address, serviceUpdate.port, serviceUpdate.secured)

--- a/src/main/scala/com/github/cupenya/gateway/Boot.scala
+++ b/src/main/scala/com/github/cupenya/gateway/Boot.scala
@@ -80,6 +80,7 @@ object Boot
         .contains(upd.namespace)
     }
     val currentResources = GatewayConfigurationManager.currentConfig().targets.keys.toList
+    log.debug(s"Discovered ${currentResources.size} services.")
 
     val toDelete = currentResources.filterNot(serviceUpdates.map(_.resource).contains)
     if (toDelete.nonEmpty) {

--- a/src/main/scala/com/github/cupenya/gateway/Config.scala
+++ b/src/main/scala/com/github/cupenya/gateway/Config.scala
@@ -1,9 +1,8 @@
 package com.github.cupenya.gateway
 
-import java.util.concurrent.TimeUnit
-
-import com.typesafe.config.ConfigFactory
 import scala.jdk.CollectionConverters._
+
+import com.typesafe.config._
 
 object Config {
   private val rootConfig = ConfigFactory.load()

--- a/src/main/scala/com/github/cupenya/gateway/client/GatewayTargetClient.scala
+++ b/src/main/scala/com/github/cupenya/gateway/client/GatewayTargetClient.scala
@@ -70,7 +70,7 @@ class GatewayTargetClient(val host: String, val port: Int, secured: Boolean)(imp
     logger.debug(s"Proxying request: $proxiedRequest")
 
     Kamon
-      .counter("proxied-requests")
+      .counter("api-gateway.proxied-requests")
       .withTag("target", host)
       .increment()
 

--- a/src/main/scala/com/github/cupenya/gateway/client/GatewayTargetClient.scala
+++ b/src/main/scala/com/github/cupenya/gateway/client/GatewayTargetClient.scala
@@ -1,21 +1,19 @@
 package com.github.cupenya.gateway.client
 
+import scala.concurrent._
+
 import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
+import akka.http.scaladsl._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.server.{ RequestContext, Route }
-import akka.stream.Materializer
-import akka.stream.scaladsl.{ Sink, Source }
-import com.github.cupenya.gateway.{ Config }
-import com.typesafe.scalalogging.StrictLogging
-
-import scala.concurrent.ExecutionContext
+import akka.http.scaladsl.server._
+import com.github.cupenya.gateway._
+import com.typesafe.scalalogging._
+import kamon.Kamon
 
 class GatewayTargetClient(val host: String, val port: Int, secured: Boolean)(implicit
     val system: ActorSystem,
-    ec: ExecutionContext,
-    materializer: Materializer
+    ec: ExecutionContext
 ) extends StrictLogging {
   private val authClient = new AuthServiceClient(
     Config.integration.authentication.host,
@@ -29,20 +27,22 @@ class GatewayTargetClient(val host: String, val port: Int, secured: Boolean)(imp
     val request         = context.request
     val originalHeaders = request.headers.toList
     val filteredHeaders = (hostHeader :: originalHeaders - Host).noEmptyHeaders
-    val eventualProxyResponse = if (secured) {
-      logger.debug(s"Need token for request ${request.uri.path}")
-      authClient.getToken(filteredHeaders).flatMap {
-        case Right(tokenResponse) =>
-          logger.debug(s"Token ${tokenResponse.jwt}")
-          val headersWithAuth = Authorization(OAuth2BearerToken(tokenResponse.jwt)) :: filteredHeaders
-          proxyRequest(context, request, headersWithAuth)
-        case Left(errorResponse) =>
-          logger.warn(s"Failed to retrieve token.")
-          context.complete(errorResponse)
+    val eventualProxyResponse =
+      if (secured) {
+        logger.debug(s"Need token for request ${request.uri.path}")
+        authClient.getToken(filteredHeaders).flatMap {
+          case Right(tokenResponse) =>
+            logger.debug(s"Token ${tokenResponse.jwt}")
+            val headersWithAuth = Authorization(OAuth2BearerToken(tokenResponse.jwt)) :: filteredHeaders
+            proxyRequest(context, request, headersWithAuth)
+          case Left(errorResponse) =>
+            logger.warn(s"Failed to retrieve token.")
+            context.complete(errorResponse)
+        }
+      } else {
+        proxyRequest(context, request, filteredHeaders)
       }
-    } else {
-      proxyRequest(context, request, filteredHeaders)
-    }
+
     eventualProxyResponse.transform(
       identity,
       t => {
@@ -53,13 +53,18 @@ class GatewayTargetClient(val host: String, val port: Int, secured: Boolean)(imp
   }
 
   private def proxyRequest(context: RequestContext, request: HttpRequest, headers: List[HttpHeader]) = {
-    val proxiedRequest = context.request.copy(
-      uri = createProxiedUri(context, request.uri),
-      headers = headers,
-      protocol = HttpProtocols.`HTTP/1.1`
-    )
+    val proxiedRequest =
+      context.request
+        .withUri(createProxiedUri(context, request.uri))
+        .withHeaders(headers)
+        .withProtocol(HttpProtocols.`HTTP/1.1`)
 
     logger.debug(s"Proxying request: $proxiedRequest")
+
+    Kamon
+      .counter("proxied-requests")
+      .withTag("target", host)
+      .increment()
 
     Http(system)
       .singleRequest(proxiedRequest)

--- a/src/main/scala/com/github/cupenya/gateway/client/package.scala
+++ b/src/main/scala/com/github/cupenya/gateway/client/package.scala
@@ -1,16 +1,13 @@
 package com.github.cupenya.gateway
 
-import akka.http.scaladsl.model.HttpHeader
-import akka.http.scaladsl.model.headers.{ ModeledCompanion, `Remote-Address` }
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers._
 
 package object client {
   implicit class RichHeaders(headers: List[HttpHeader]) {
 
     def noEmptyHeaders: List[HttpHeader] =
       headers.filterNot(_.value.isEmpty)
-
-    def valueOf[T](header: ModeledCompanion[T]): Option[String] =
-      headers.find(_.is(`Remote-Address`.lowercaseName)).map(_.value)
 
     def -[T](header: ModeledCompanion[T]): List[HttpHeader] =
       headers.filterNot(_.is(header.lowercaseName))

--- a/src/main/scala/com/github/cupenya/gateway/server/ApiDashboardService.scala
+++ b/src/main/scala/com/github/cupenya/gateway/server/ApiDashboardService.scala
@@ -1,16 +1,15 @@
 package com.github.cupenya.gateway.server
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server.Directives
-import akka.stream.Materializer
-import akka.util.Timeout
-import com.github.cupenya.gateway.configuration.GatewayConfigurationManager
-import com.github.cupenya.gateway.model.GatewayTarget
-import spray.json.DefaultJsonProtocol
+import scala.concurrent._
 
-import scala.concurrent.ExecutionContext
+import akka.actor.ActorSystem
+import akka.http.scaladsl.marshallers.sprayjson._
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server._
+import akka.util._
+import com.github.cupenya.gateway.configuration._
+import com.github.cupenya.gateway.model._
+import spray.json.DefaultJsonProtocol
 
 trait Protocols extends DefaultJsonProtocol with SprayJsonSupport {
   implicit val serviceRouteFormat         = jsonFormat3(ServiceRoute)
@@ -23,11 +22,7 @@ trait ApiDashboardService extends Directives with Protocols {
   import scala.language.postfixOps
 
   implicit val system: ActorSystem
-
   implicit def ec: ExecutionContext
-
-  implicit val materializer: Materializer
-
   implicit val timeout = Timeout(5 seconds)
 
   private val DEFAULT_PORT = 80

--- a/src/main/scala/com/github/cupenya/gateway/server/GatewayHttpService.scala
+++ b/src/main/scala/com/github/cupenya/gateway/server/GatewayHttpService.scala
@@ -1,18 +1,17 @@
 package com.github.cupenya.gateway.server
 
+import scala.annotation._
+import scala.concurrent._
+
 import akka.actor.ActorSystem
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.marshallers.sprayjson._
 import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.server._
-import akka.stream.Materializer
+import com.github.cupenya.gateway._
 import com.github.cupenya.gateway.client.{ AuthServiceClient, GatewayTargetClient, LoginData }
-import com.github.cupenya.gateway.configuration.{ GatewayConfiguration, GatewayConfigurationManager }
-import com.github.cupenya.gateway.Config
-import com.typesafe.scalalogging.StrictLogging
+import com.github.cupenya.gateway.configuration._
+import com.typesafe.scalalogging._
 import spray.json.DefaultJsonProtocol
-
-import scala.annotation.tailrec
-import scala.concurrent.ExecutionContext
 
 trait GatewayTargetDirectives extends Directives {
   def serviceRouteForResource(config: GatewayConfiguration, prefix: String): Directive[Tuple1[GatewayTargetClient]] =
@@ -70,11 +69,7 @@ trait GatewayHttpService
     with Directives {
 
   implicit def system: ActorSystem
-
   implicit def ec: ExecutionContext
-
-  implicit val materializer: Materializer
-
   implicit val loginDataFormat = jsonFormat2(LoginData)
 
   val gatewayRoute: Route = (ctx: RequestContext) =>

--- a/src/main/scala/com/github/cupenya/service/discovery/KubernetesServiceDiscoveryClient.scala
+++ b/src/main/scala/com/github/cupenya/service/discovery/KubernetesServiceDiscoveryClient.scala
@@ -7,15 +7,14 @@ import scala.concurrent._
 import scala.util.Try
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl._
 import akka.http.scaladsl.client.RequestBuilding._
 import akka.http.scaladsl.marshallers.sprayjson._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.settings._
 import akka.http.scaladsl.unmarshalling._
-import akka.http.scaladsl._
 import akka.stream._
-import akka.stream.scaladsl.{ Sink, Source }
+import akka.stream.scaladsl.Sink
 import javax.net.ssl._
 import spray.json._
 
@@ -24,6 +23,7 @@ class KubernetesServiceDiscoveryClient()(implicit system: ActorSystem, ec: Execu
     with KubernetesServiceUpdateParser
     with SprayJsonSupport
     with Logging {
+  override def name: String = "Kubernetes API"
 
   // FIXME: get rid of SSL hack
   private val trustAllCerts: Array[TrustManager] = Array(new X509TrustManager() {
@@ -47,36 +47,19 @@ class KubernetesServiceDiscoveryClient()(implicit system: ActorSystem, ec: Execu
       Http(system).defaultClientHttpsContext
     }
 
-  private lazy val client =
-    if (port == 443) {
-      Http(system).outgoingConnectionHttps(
-        host,
-        port,
-        connectionContext = ConnectionContext.httpsClient(ssl),
-        settings = ClientConnectionSettings(system)
-      )
-    } else {
-      Http(system).outgoingConnection(host, port, settings = ClientConnectionSettings(system))
-    }
-
-  private val req =
-    Get(s"/api/v1/services")
+  private val request =
+    Get(s"https://${host}:${port}/api/v1/services")
       .withHeaders(
         Connection("Keep-Alive"),
         Authorization(OAuth2BearerToken(Config.`service-discovery`.kubernetes.token))
       )
 
   def healthCheck: Future[_] =
-    Source.single(req).via(client).runWith(Sink.head).filter(_.status.isSuccess())
+    Http()
+      .singleRequest(request, connectionContext)
+      .filter(_.status.isSuccess())
 
   def listServices: Future[List[KubernetesServiceUpdate]] = {
-    val request =
-      Get(s"https://${host}:${port}/api/v1/services")
-        .withHeaders(
-          Connection("Keep-Alive"),
-          Authorization(OAuth2BearerToken(Config.`service-discovery`.kubernetes.token))
-        )
-
     Http()
       .singleRequest(request, connectionContext)
       .flatMap { response =>
@@ -109,43 +92,6 @@ class KubernetesServiceDiscoveryClient()(implicit system: ActorSystem, ec: Execu
           )
       }
   }
-
-  def listServicesOld: Future[List[KubernetesServiceUpdate]] =
-    Source
-      .single(req)
-      .via(client)
-      .mapAsync(1)(res =>
-        Unmarshal(res.entity)
-          .to[ServiceList]
-          .map(
-            _.items.flatMap(so =>
-              so.metadata.labels
-                .flatMap(_.get("resource"))
-                .map(resource => {
-                  val ksu = KubernetesServiceUpdate(
-                    UpdateType.Addition,
-                    cleanMetadataString(so.metadata.name),
-                    cleanMetadataString(resource),
-                    cleanMetadataString(so.metadata.namespace),
-                    so.spec.ports.headOption.map(_.port).getOrElse(DEFAULT_PORT),
-                    so.metadata.labels
-                      .flatMap(_.get("secured"))
-                      .flatMap(value => Try(value.toBoolean).toOption)
-                      .getOrElse(true), // Default is secured
-                    so.metadata.annotations
-                      .flatMap(_.get("permissions"))
-                      .flatMap(value => Try(value.parseJson.convertTo[List[Permission]]).toOption)
-                      .getOrElse(Nil)
-                  )
-                  log.debug(s"Got Kubernetes service update $ksu")
-                  ksu
-                })
-            )
-          )
-      )
-      .runWith(Sink.head)
-
-  override def name: String = "Kubernetes API"
 }
 
 trait KubernetesServiceUpdateParser extends DefaultJsonProtocol with Logging {

--- a/src/main/scala/com/github/cupenya/service/discovery/KubernetesServiceDiscoveryClient.scala
+++ b/src/main/scala/com/github/cupenya/service/discovery/KubernetesServiceDiscoveryClient.scala
@@ -57,6 +57,10 @@ class KubernetesServiceDiscoveryClient()(implicit system: ActorSystem, ec: Execu
   def healthCheck: Future[_] =
     Http()
       .singleRequest(request, connectionContext)
+      .map { response =>
+        response.discardEntityBytes()
+        response
+      }
       .filter(_.status.isSuccess())
 
   def listServices: Future[List[KubernetesServiceUpdate]] = {

--- a/src/main/scala/com/github/cupenya/service/discovery/KubernetesServiceDiscoveryClient.scala
+++ b/src/main/scala/com/github/cupenya/service/discovery/KubernetesServiceDiscoveryClient.scala
@@ -74,7 +74,7 @@ class KubernetesServiceDiscoveryClient()(implicit system: ActorSystem, ec: Execu
               so.metadata.labels
                 .flatMap(_.get("resource"))
                 .map(resource => {
-                  val ksu = KubernetesServiceUpdate(
+                  KubernetesServiceUpdate(
                     UpdateType.Addition,
                     cleanMetadataString(so.metadata.name),
                     cleanMetadataString(resource),
@@ -89,8 +89,6 @@ class KubernetesServiceDiscoveryClient()(implicit system: ActorSystem, ec: Execu
                       .flatMap(value => Try(value.parseJson.convertTo[List[Permission]]).toOption)
                       .getOrElse(Nil)
                   )
-                  log.debug(s"Got Kubernetes service update $ksu")
-                  ksu
                 })
             )
           )

--- a/src/main/scala/com/github/cupenya/service/discovery/ServiceDiscoveryAgent.scala
+++ b/src/main/scala/com/github/cupenya/service/discovery/ServiceDiscoveryAgent.scala
@@ -49,9 +49,17 @@ class ServiceDiscoveryAgent[T <: ServiceUpdate](
 
   def watchServices(): Unit = {
     system.scheduler.schedule(1.second, SERVICE_POLLING_INTERVAL.seconds) {
-      serviceDiscoverySource.listServices.map(handleServiceUpdates).failed.foreach { t =>
-        log.error(s"Couldn't list services: ${t.getMessage}", t)
-      }
+      serviceDiscoverySource
+        .listServices
+        .map { services =>
+          log.debug(s"Discovered ${services.size} services.")
+          services
+        }
+        .map(handleServiceUpdates)
+        .failed.foreach { t =>
+          t.printStackTrace()
+          log.error(s"Couldn't list services: ${t.getMessage}", t)
+        }
     }
   }
 

--- a/src/main/scala/com/github/cupenya/service/discovery/ServiceDiscoveryAgent.scala
+++ b/src/main/scala/com/github/cupenya/service/discovery/ServiceDiscoveryAgent.scala
@@ -48,7 +48,7 @@ class ServiceDiscoveryAgent[T <: ServiceUpdate](
   }
 
   def watchServices(): Unit = {
-    system.scheduler.schedule(SERVICE_POLLING_INTERVAL seconds, 5 seconds) {
+    system.scheduler.schedule(1.second, SERVICE_POLLING_INTERVAL.seconds) {
       serviceDiscoverySource.listServices.map(handleServiceUpdates).failed.foreach { t =>
         log.error(s"Couldn't list services: ${t.getMessage}", t)
       }

--- a/src/main/scala/com/github/cupenya/service/discovery/ServiceDiscoveryAgent.scala
+++ b/src/main/scala/com/github/cupenya/service/discovery/ServiceDiscoveryAgent.scala
@@ -56,7 +56,8 @@ class ServiceDiscoveryAgent[T <: ServiceUpdate](
           services
         }
         .map(handleServiceUpdates)
-        .failed.foreach { t =>
+        .failed
+        .foreach { t =>
           t.printStackTrace()
           log.error(s"Couldn't list services: ${t.getMessage}", t)
         }

--- a/src/main/scala/com/github/cupenya/service/discovery/ServiceDiscoveryAgent.scala
+++ b/src/main/scala/com/github/cupenya/service/discovery/ServiceDiscoveryAgent.scala
@@ -50,14 +50,9 @@ class ServiceDiscoveryAgent[T <: ServiceUpdate](
   def watchServices(): Unit = {
     system.scheduler.schedule(1.second, SERVICE_POLLING_INTERVAL.seconds) {
       serviceDiscoverySource.listServices
-        .map { services =>
-          log.debug(s"Discovered ${services.size} services.")
-          services
-        }
         .map(handleServiceUpdates)
         .failed
         .foreach { t =>
-          t.printStackTrace()
           log.error(s"Couldn't list services: ${t.getMessage}", t)
         }
     }

--- a/src/main/scala/com/github/cupenya/service/discovery/ServiceDiscoveryAgent.scala
+++ b/src/main/scala/com/github/cupenya/service/discovery/ServiceDiscoveryAgent.scala
@@ -49,8 +49,7 @@ class ServiceDiscoveryAgent[T <: ServiceUpdate](
 
   def watchServices(): Unit = {
     system.scheduler.schedule(1.second, SERVICE_POLLING_INTERVAL.seconds) {
-      serviceDiscoverySource
-        .listServices
+      serviceDiscoverySource.listServices
         .map { services =>
           log.debug(s"Discovered ${services.size} services.")
           services

--- a/src/main/scala/com/github/cupenya/service/discovery/health/HealthCheckRoute.scala
+++ b/src/main/scala/com/github/cupenya/service/discovery/health/HealthCheckRoute.scala
@@ -1,21 +1,19 @@
 package com.github.cupenya.service.discovery.health
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server.Directives
-import akka.stream.Materializer
-import com.github.cupenya.service.discovery.{ Config, Logging }
-import spray.json.DefaultJsonProtocol
+import scala.concurrent._
 
-import scala.concurrent.ExecutionContext
+import akka.actor.ActorSystem
+import akka.http.scaladsl.marshallers.sprayjson._
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server._
+import com.github.cupenya.service.discovery._
+import spray.json.DefaultJsonProtocol
 
 trait HealthCheckRoute extends Directives with DefaultJsonProtocol with SprayJsonSupport with Logging {
   self: HealthCheckService =>
 
   implicit def ec: ExecutionContext
   implicit def system: ActorSystem
-  implicit def materializer: Materializer
 
   case class HealthCheckResults(statuses: List[HealthCheckResult])
 

--- a/src/main/scala/com/github/cupenya/service/discovery/health/HealthCheckService.scala
+++ b/src/main/scala/com/github/cupenya/service/discovery/health/HealthCheckService.scala
@@ -13,7 +13,7 @@ trait HealthCheckService {
   def checks: List[HealthCheck]
 
   def runChecks()(implicit ec: ExecutionContext, actorSystem: ActorSystem): Future[List[HealthCheckResult]] =
-    Future.sequence(checks.map(_.checkWithRecovery))
+    Future.sequence(checks.map(_.checkWithRecovery()))
 
   implicit class RichHealthCheck(check: HealthCheck) {
     def checkWithRecovery()(implicit ec: ExecutionContext, actorSystem: ActorSystem): Future[HealthCheckResult] =


### PR DESCRIPTION
This PR:

- adds Kamon with the datadog exporter and the Http and System instrumentation sets active
- switches configuration from explicit overrides in the K8s deployment to nice environment vars
- reimplements the Kubernetes client to use the simpler `singleRequest` API because the old code was producing errors on latest versions of Akka Http and Akka
- upgrades the project to the latest Scala, sbt, and dependencies
- switches to the latest Java 11 docker base image